### PR TITLE
Make bot respond to api requests without waiting for discord.

### DIFF
--- a/src/api/messages/index.ts
+++ b/src/api/messages/index.ts
@@ -8,6 +8,7 @@ import { asyncErrorHandler } from "../utils/asyncErrorHandler";
 import { ChannelMessage } from "../zodSchemas/ChannelMessage";
 import { DirectMessage } from "../zodSchemas/DirectMessage";
 import { config } from "../../../config";
+import { sendMessageDetailsIfIncluded } from "../utils/sendMessageDetailsIfIncluded";
 
 export const messages = express.Router();
 
@@ -16,26 +17,24 @@ messages.post(
   ChannelMessageValidator,
   asyncErrorHandler(async (req, res) => {
     const { id } = req.params;
-    const { message, embed }: ChannelMessage = req.body;
-
-    const { id: messageId } = await bot.sendChannelMessage(message, id, embed);
-    return res.status(201).json({ id: messageId });
+    const { message, embed, includeDetails }: ChannelMessage = req.body;
+    const botPromise = bot.sendChannelMessage(message, id, embed);
+    await sendMessageDetailsIfIncluded(includeDetails, botPromise, res);
   })
 );
 
 messages.post(
-  "/lessonChannel/:id",
+  "/lessonChannel/:lessonId",
   ChannelMessageValidator,
   asyncErrorHandler(async (req, res) => {
-    const { id } = req.params;
-    const { message, embed }: ChannelMessage = req.body;
-
-    const { id: messageId } = await bot.sendChannelMessage(
+    const { lessonId } = req.params;
+    const { message, embed, includeDetails }: ChannelMessage = req.body;
+    const botPromise = bot.sendChannelMessage(
       message,
-      config.lessonChannels[id],
+      config.lessonChannels[lessonId],
       embed
     );
-    return res.status(201).json({ id: messageId });
+    await sendMessageDetailsIfIncluded(includeDetails, botPromise, res);
   })
 );
 
@@ -44,9 +43,8 @@ messages.post(
   DirectMessageValidator,
   asyncErrorHandler(async (req, res) => {
     const { userId } = req.params;
-    const { message, embed }: DirectMessage = req.body;
-
-    const { id } = await bot.sendDirectMessage(message, userId, embed);
-    return res.status(201).json({ id });
+    const { message, embed, includeDetails }: DirectMessage = req.body;
+    const botPromise = bot.sendDirectMessage(message, userId, embed);
+    await sendMessageDetailsIfIncluded(includeDetails, botPromise, res);
   })
 );

--- a/src/api/middlewares/errorHandler.ts
+++ b/src/api/middlewares/errorHandler.ts
@@ -7,30 +7,50 @@ enum ErrorType {
   api_error = "api_error",
 }
 
+interface BotErrorBase {
+  type: ErrorType;
+  message: string;
+}
+
+export interface BotAuthError extends BotErrorBase {
+  type: ErrorType.auth_error;
+}
+
+export interface BotValidationError extends BotErrorBase {
+  type: ErrorType.validation_error;
+  issues: { [key: string]: string }[];
+}
+
+export interface BotApiError extends BotErrorBase {
+  type: ErrorType.api_error;
+}
+
+export type BotError = BotAuthError | BotValidationError | BotApiError;
+
 export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
+  // Unknown Error
+  let status = 500;
+  let error: BotError = { type: ErrorType.api_error, message: err.message };
+
   // Incorrect Auth Token
   if (err.name === "AuthError") {
-    return res
-      .status(401)
-      .json({ error: { type: ErrorType.auth_error, message: err.message } });
+    status = 401;
+    error = { type: ErrorType.auth_error, message: err.message };
   }
 
   // Validation error
   if (err instanceof ZodError) {
-    return res.status(400).json({
-      error: {
-        type: ErrorType.validation_error,
-        message: "One or more fields were missing or invalid.",
-        issues: err.issues.map(({ path, message }) => ({
-          path: path.join("."),
-          message,
-        })),
-      },
-    });
+    status = 400;
+    error = {
+      type: ErrorType.validation_error,
+      message: "One or more fields were missing or invalid.",
+      issues: err.issues.map(({ path, message }) => ({
+        path: path.join("."),
+        message,
+      })),
+    };
   }
 
-  // Unknown Error
-  return res
-    .status(500)
-    .json({ error: { type: ErrorType.api_error, message: err.message } });
+  console.error(error);
+  if (!res.headersSent) res.status(status).json(error);
 };

--- a/src/api/submissions/index.ts
+++ b/src/api/submissions/index.ts
@@ -2,6 +2,8 @@ import express from "express";
 import { bot } from "../../../index";
 import { asyncErrorHandler } from "../utils/asyncErrorHandler";
 import { SubmissionNotificationValidator } from "../middlewares/validators";
+import { sendMessageDetailsIfIncluded } from "../utils/sendMessageDetailsIfIncluded";
+import { SubmissionNotification } from "../zodSchemas/SubmissionNotification";
 
 export const submissions = express.Router();
 
@@ -9,7 +11,8 @@ submissions.post(
   "/notifications",
   SubmissionNotificationValidator,
   asyncErrorHandler(async (req, res) => {
-    const { id: messageId } = await bot.sendSubmissionNotification(req.body);
-    return res.status(201).json({ id: messageId });
+    const { includeDetails }: SubmissionNotification = req.body;
+    const botPromise = bot.sendSubmissionNotification(req.body);
+    await sendMessageDetailsIfIncluded(includeDetails, botPromise, res);
   })
 );

--- a/src/api/utils/sendMessageDetailsIfIncluded.ts
+++ b/src/api/utils/sendMessageDetailsIfIncluded.ts
@@ -1,0 +1,14 @@
+import { Message } from "discord.js";
+import { Response } from "express";
+
+export const sendMessageDetailsIfIncluded = async (
+  includeDetails: boolean,
+  botPromise: Promise<Message>,
+  res: Response
+) => {
+  if (!includeDetails) {
+    res.status(202).json({ status: "sending" });
+  }
+  const { id } = await botPromise;
+  if (!res.headersSent) res.status(201).json({ id });
+};

--- a/src/api/zodSchemas/ChannelMessage.ts
+++ b/src/api/zodSchemas/ChannelMessage.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
-import {MessageEmbedOptionsShape} from "../utils/MessageEmbedOptionsShape";
+import { MessageEmbedOptionsShape } from "../utils/MessageEmbedOptionsShape";
 
 export const ChannelMessageSchema = z
   .object({
     message: z.string(),
     embed: z.object(MessageEmbedOptionsShape).strict().optional(),
+    includeDetails: z.boolean().optional().default(false),
   })
   .strict();
 

--- a/src/api/zodSchemas/DirectMessage.ts
+++ b/src/api/zodSchemas/DirectMessage.ts
@@ -5,6 +5,7 @@ export const DirectMessageSchema = z
   .object({
     message: z.string(),
     embed: z.object(MessageEmbedOptionsShape).strict().optional(),
+    includeDetails: z.boolean().optional().default(false),
   })
   .strict();
 

--- a/src/api/zodSchemas/SubmissionNotification.ts
+++ b/src/api/zodSchemas/SubmissionNotification.ts
@@ -7,6 +7,7 @@ export const SubmissionNotificationSchema = z.object({
   notificationLessonId: z.string().min(1),
   lessonId: z.string().min(1),
   challengeTitle: z.string().min(1),
+  includeDetails: z.boolean().optional().default(false),
 });
 
 export type SubmissionNotification = z.infer<


### PR DESCRIPTION
The current uses of the bot don't require waiting for a response from discord that the message has been sent. This PR changes the default behaviour of api routes to respond with a `202 Created` right after a request to send a message to discord has started without waiting for it to complete. An additional, optional, boolean parameter `includeDetails` can be passed in the JSON body of the request if the caller requires to wait for the discord message to be created and receive the id of the created message back.

An additional change made in this PR is that the errorHandler middleware now logs the errors using `console.error` (to be replaced with winston) and it responds to the client with the error only after checking `res.headersSend` i.e. it won't sent a response if a route has already done so.

### TODO
- [ ]  Update api doc once merged