### PR TITLE
Hotfix: Convert lesson notifications to use new slug urls

### DIFF
--- a/src/Bot/index.ts
+++ b/src/Bot/index.ts
@@ -34,7 +34,7 @@ class Bot {
     idType,
     id,
     notificationLessonId,
-    lessonId,
+    lessonSlug,
     challengeTitle,
   }: SubmissionMessage): Promise<Message> => {
     const userString = idType === IdType.C0D3 ? `**${id}**` : `<@${id}>`;
@@ -42,10 +42,10 @@ class Bot {
     const embed = new MessageEmbed()
       .setColor("#5440d8")
       .setTitle("New Submission")
-      .setURL(`https://www.c0d3.com/review/${lessonId}`)
+      .setURL(`https://www.c0d3.com/review/${lessonSlug}`)
       .setDescription(
         `${userString} has submitted a solution to **_${challengeTitle}_**.
-    Click [here](https://www.c0d3.com/review/${lessonId}) to review code`
+    Click [here](https://www.c0d3.com/review/${lessonSlug}) to review code`
       )
       .setTimestamp();
 

--- a/src/api/zodSchemas/SubmissionNotification.ts
+++ b/src/api/zodSchemas/SubmissionNotification.ts
@@ -5,7 +5,7 @@ export const SubmissionNotificationSchema = z.object({
   idType: z.nativeEnum(IdType),
   id: z.string().min(1),
   notificationLessonId: z.string().min(1),
-  lessonId: z.string().min(1),
+  lessonSlug: z.string().min(1),
   challengeTitle: z.string().min(1),
   includeDetails: z.boolean().optional().default(false),
 });


### PR DESCRIPTION
Update review links to `review/<lesson_slug>` to stay in sync with new c0d3-app update https://github.com/garageScript/c0d3-app/pull/1041#issue-715499612