### PR TITLE
Bump docker node from 14 to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine AS BuildBot
+FROM node:17-alpine AS BuildBot
 WORKDIR /usr/src/bot
 COPY package.json .
 COPY yarn.lock .
@@ -7,7 +7,7 @@ RUN yarn install
 COPY . .
 RUN yarn run build
 
-FROM node:14-alpine
+FROM node:17-alpine
 WORKDIR /usr/src/bot
 COPY package.json .
 COPY yarn.lock .


### PR DESCRIPTION
https://github.com/garageScript/c0d3r/pull/19 doesn't work with node v14. This PR bump docker node image to v17