### PR TITLE
fix: invalid bot ID

### DIFF
--- a/src/Bot/index.ts
+++ b/src/Bot/index.ts
@@ -83,7 +83,7 @@ class Bot {
     rest
       .put(
         Routes.applicationGuildCommands(
-          config.botAccessToken,
+          config.botToken,
           config.guildId
         ),
         {


### PR DESCRIPTION
This PR replace `botAccessToken` with `botToken`