### PR TITLE
Perform linting and fix errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
   "license": "MIT",
   "scripts": {
     "start": "ts-node index.ts",
-    "build": "tsc -p tsconfig.json",
-    "prettier:check": "prettier --check src --no-error-on-unmatched-pattern",
-    "prettier:fix": "prettier --write src --ignore-unknown --no-error-on-unmatched-pattern"
+    "prettier:check": "prettier --check . --no-error-on-unmatched-pattern",
+    "prettier:fix": "prettier --write . --ignore-unknown --no-error-on-unmatched-pattern",
+    "lint:check": "eslint --cache .",
+    "lint:fix": "eslint --cache --fix .",
+    "check": "yarn lint:check && yarn prettier:check",
+    "fix": "yarn lint:fix && yarn prettier:fix",
+    "clean": "rm -rf dist",
+    "build": "yarn clean && tsc"
   },
   "dependencies": {
     "@discordjs/builders": "^0.12.0",

--- a/src/Bot/events/index.ts
+++ b/src/Bot/events/index.ts
@@ -5,6 +5,8 @@ import { message } from "./message";
 export interface BotEvent {
   name: string;
   once?: boolean;
+  // Discord.js provides ...any[] as arguments to the execute callback
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   execute: (...args: any[]) => void;
 }
 

--- a/src/Bot/index.ts
+++ b/src/Bot/index.ts
@@ -71,10 +71,13 @@ class Bot {
     message: string,
     channelId: string,
     embed?: MessageEmbed | MessageEmbedOptions
-  ): Promise<Message> =>
-    (this.client.channels.cache.get(channelId) as TextChannel).send(
-      message ? message : { embeds: [embed!] }
-    );
+  ): Promise<Message> => {
+    const channel =
+      this.client.channels.cache.get(channelId) ??
+      (await this.client.channels.fetch(channelId));
+    const embeds = embed ? [embed] : embed;
+    return (channel as TextChannel).send(message ? message : { embeds });
+  };
 
   sendDirectMessage = async (
     message: string,
@@ -84,13 +87,12 @@ class Bot {
     const user =
       this.client.users.cache.get(userId) ??
       (await this.client.users.fetch(userId));
-    return user.send(message ? message : { embeds: [embed!] });
+    const embeds = embed ? [embed] : embed;
+    return user.send(message ? message : { embeds });
   };
 
   registerCommands = async () => {
-    const rest = new REST({ version: "9" }).setToken(
-      config.discordToken
-    );
+    const rest = new REST({ version: "9" }).setToken(config.discordToken);
 
     rest
       .put(Routes.applicationGuildCommands(config.clientId, config.guildId), {

--- a/src/api/middlewares/errorHandler.ts
+++ b/src/api/middlewares/errorHandler.ts
@@ -27,7 +27,7 @@ export interface BotApiError extends BotErrorBase {
 
 export type BotError = BotAuthError | BotValidationError | BotApiError;
 
-export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
+export const errorHandler: ErrorRequestHandler = (err, _req, res) => {
   // Unknown Error
   let status = 500;
   let error: BotError = { type: ErrorType.api_error, message: err.message };

--- a/src/api/utils/asyncErrorHandler.ts
+++ b/src/api/utils/asyncErrorHandler.ts
@@ -1,17 +1,6 @@
 import { RequestHandler } from "express";
-import {
-  NextFunction,
-  ParamsDictionary,
-  Query,
-  Request,
-  Response,
-} from "express-serve-static-core";
+import { NextFunction, Request, Response } from "express-serve-static-core";
 
 export const asyncErrorHandler =
-  (fn: RequestHandler) =>
-  (
-    req: Request<ParamsDictionary, any, any, Query>,
-    res: Response,
-    next: NextFunction
-  ) =>
+  (fn: RequestHandler) => (req: Request, res: Response, next: NextFunction) =>
     Promise.resolve(fn(req, res, next)).catch(next);

--- a/src/api/utils/validatorFactory.ts
+++ b/src/api/utils/validatorFactory.ts
@@ -2,8 +2,8 @@ import { ZodSchema } from "zod";
 import { RequestHandler } from "express";
 
 export const validatorFactory =
-  (schema: ZodSchema<any>): RequestHandler =>
-  (req, res, next) => {
+  (schema: ZodSchema): RequestHandler =>
+  (req, _res, next) => {
     req.body = schema.parse(req.body);
     next();
   };


### PR DESCRIPTION
Created new scripts in package.json to perform linting.
Updated build script to clean build directory before building.

 - Remove unused next arg, and prefix unused req arg with an underscore in errorHandler middleware
 - Remove unnecessary type annotation and let ts infer type in asyncErrorHandler middleware
 - Remove unnecessary type annotation in zod validatorFactory
 - Remove non null assertion and replace it with explicit checks in bot/index.ts
 - Ignore unavoidable ts lint error in Bot/events and add explanatory comment