### PR TITLE
Update README.md with instructions for .env keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,48 @@ The production bot runs on the c0d3 CapRover server and can be communicated with
 
 ## Development - Getting Started
 
-\* First you need to register a discord application to get the `DISCORD_TOKEN` that c0d3r will use to forward your commands to your discord server. A guide for that setup can be found on the wiki page here: [Registering a Discord Bot](https://github.com/garageScript/c0d3r/wiki/Registering-a-Discord-Bot#registering-a-discord-bot)
+First you need to register a discord application to get the `BOT_TOKEN` that c0d3r will use to forward your commands to your discord server. A guide for that setup can be found on the wiki page here: [Registering a Discord Bot](https://github.com/garageScript/c0d3r/wiki/Registering-a-Discord-Bot#registering-a-discord-bot)
 
-- ## Using yarn
+## Setting the .env variables
+
+Copy and rename `example.env` to `.env` and fill the required variables below
+
+`DISCORD_TOKEN`: to find your Discord token, you can [follow these instructions](https://www.androidauthority.com/get-discord-token-3149920/).
+
+`BOT_TOKEN`: Ensure you have followed the above instructions for registering the application/bot.
+
+- Go to the [Discord developer portal](https://discord.com/developers/applications)
+- Click on your application/bot
+- Go to the Bot tab, and click the "Reset Token" button and copy the token.
+
+`CLIENT_ID`:
+
+- Go to the [Discord developer portal](https://discord.com/developers/applications)
+- Click on your application/bot
+- Go to the OAuth2 tab, and you will find the `CLIENT_ID` under "Client information"
+
+`GRAPHQL_API`: This should be `http://localhost:3000/api/graphql` when running locally.
+
+`GUILD_ID`: First enable discord developer mode:
+
+- Click the gear icon in the bottom-left of the Discord app to open User Settings
+- Click the App Settings > Advanced tab
+- Turn on Developer Mode
+- Exit out of User Settings
+- Right-click on the server in which you will be testing the bot
+- Click the "Copy Server ID" button
+
+`OPENAI_API_KEY`: Get this from the c0d3-app engineering team.
+
+---
+
+## Using yarn to start the bot
 
 1. Run `yarn` to install dependencies
-2. Copy and rename `example.env` to `.env` and fill the required variables.
+2. Ensure that all `.env` variables have been set per the instructions above
 3. Run `yarn start` to start the bot.
 
-- ## Using Docker
+## Using Docker to start the bot
 
 1. Run `docker build -t c0d3r .` to build the image
 2. Run `docker run --env DISCORD_TOKEN=token --env BOT_TOKEN=token c0d3r` to start a new container with the bot. The env variables are required.


### PR DESCRIPTION
### Overview

Having gone through this process myself to run the c0d3 bot locally, I thought it would be nice to update the README to include instructions on where to find the several `.env` keys required to start the bot.