### PR TITLE
Fix error handler middleware

### DIFF
--- a/src/api/middlewares/errorHandler.ts
+++ b/src/api/middlewares/errorHandler.ts
@@ -27,7 +27,9 @@ export interface BotApiError extends BotErrorBase {
 
 export type BotError = BotAuthError | BotValidationError | BotApiError;
 
-export const errorHandler: ErrorRequestHandler = (err, _req, res) => {
+// The functions needs to take all four parameters to be an express error handler
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
   // Unknown Error
   let status = 500;
   let error: BotError = { type: ErrorType.api_error, message: err.message };


### PR DESCRIPTION
Express error handlers need to take four arguments necessarily https://expressjs.com/en/guide/error-handling.html#writing-error-handlers This PR updates the error handler to take 4 args as required.