### PR TITLE
Fix unaddressed migration remnants 

### DIFF
--- a/src/Bot/commands/commandsReplies.ts
+++ b/src/Bot/commands/commandsReplies.ts
@@ -16,11 +16,11 @@ const graphQLClient = new GraphQLClient(config.graphqlAPI);
 
 export const lookupReply = async (interaction: CommandInteraction) => {
   try {
-    const usernameArg = interaction.options.get("username");
+    const usernameOption = interaction.options.get("username");
     await interaction.deferReply({ ephemeral: true });
 
     const data = (await graphQLClient.request(USER_INFO, {
-      username: usernameArg,
+      username: usernameOption?.value || "",
     })) as UserInfoQuery;
 
     const userInfo = data?.userInfo;
@@ -30,14 +30,15 @@ export const lookupReply = async (interaction: CommandInteraction) => {
     if (discordUserId) {
       // <@${discordUserId}> is used to create a link for the user profile
       await interaction.editReply({
-        content: `${usernameArg} on Discord is <@${discordUserId}>`,
+        content: `${usernameOption?.value} on Discord is <@${discordUserId}>`,
       });
     } else {
       await interaction.editReply({
-        content: `${usernameArg} is not connected to Discord.`,
+        content: `${usernameOption?.value} is not connected to Discord.`,
       });
     }
   } catch (err) {
+    console.log(err);
     await interaction.editReply({ content: "We could not find the user." });
   }
 };

--- a/src/Bot/commands/commandsReplies.ts
+++ b/src/Bot/commands/commandsReplies.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, CommandInteraction } from "discord.js";
+import { ChatInputCommandInteraction } from "discord.js";
 import { GraphQLClient } from "graphql-request";
 import { USER_INFO } from "../../graphql";
 import { config } from "../../../config";
@@ -14,13 +14,13 @@ type UserInfoQuery = {
 
 const graphQLClient = new GraphQLClient(config.graphqlAPI);
 
-export const lookupReply = async (interaction: CommandInteraction) => {
+export const lookupReply = async (interaction: ChatInputCommandInteraction) => {
   try {
-    const usernameOption = interaction.options.get("username");
+    const username = interaction.options.getString("username") ?? "";
     await interaction.deferReply({ ephemeral: true });
 
     const data = (await graphQLClient.request(USER_INFO, {
-      username: usernameOption?.value || "",
+      username: username,
     })) as UserInfoQuery;
 
     const userInfo = data?.userInfo;
@@ -30,15 +30,14 @@ export const lookupReply = async (interaction: CommandInteraction) => {
     if (discordUserId) {
       // <@${discordUserId}> is used to create a link for the user profile
       await interaction.editReply({
-        content: `${usernameOption?.value} on Discord is <@${discordUserId}>`,
+        content: `${username} on Discord is <@${discordUserId}>`,
       });
     } else {
       await interaction.editReply({
-        content: `${usernameOption?.value} is not connected to Discord.`,
+        content: `${username} is not connected to Discord.`,
       });
     }
   } catch (err) {
-    console.log(err);
     await interaction.editReply({ content: "We could not find the user." });
   }
 };

--- a/src/Bot/events/index.ts
+++ b/src/Bot/events/index.ts
@@ -1,4 +1,4 @@
-import { Message } from "discord.js";
+import { Events, Message } from "discord.js";
 import { bot } from "../../../index";
 import { message } from "./message";
 
@@ -11,7 +11,7 @@ export interface BotEvent {
 }
 
 export interface MessageEvent extends BotEvent {
-  name: "message";
+  name: Events;
   execute: (message: Message) => void;
 }
 

--- a/src/Bot/events/message.ts
+++ b/src/Bot/events/message.ts
@@ -1,9 +1,9 @@
 import { MessageEvent } from "./index";
 import { config } from "../../../config";
-import { MessageType } from "discord.js";
+import { Events, MessageType } from "discord.js";
 
 export const message: MessageEvent = {
-  name: "message",
+  name: Events.MessageCreate,
   execute: (message) => {
     if (
       message.channel.id === config.channels.welcome &&


### PR DESCRIPTION
## Changes

- Make the `lookup` command work but extract the necessary properties from the option. Previously, the option used to be a single string value and not an object.
- Make the bot welcome new users by using the correct event name.